### PR TITLE
feat: allow changing symbol for unknown kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ require("nvim-lsp-endhints").setup {
 	icons = {
 		type = "󰜁 ",
 		parameter = "󰏪 ",
+		unknown = "[?] ",
 	},
 	label = {
 		padding = 1,

--- a/lua/lsp-endhints/config.lua
+++ b/lua/lsp-endhints/config.lua
@@ -6,6 +6,7 @@ local defaultConfig = {
 	icons = {
 		type = "󰜁 ",
 		parameter = "󰏪 ",
+		unknown = "[?] ",
 	},
 	label = {
 		padding = 1,

--- a/lua/lsp-endhints/override-handler.lua
+++ b/lua/lsp-endhints/override-handler.lua
@@ -69,7 +69,7 @@ function M.refreshHandler()
 				if lastKind == hint.kind then
 					hintsMerged = hintsMerged .. ", " .. hint.label
 				else
-					local icon = config.icons[hint.kind] or "[?]"
+					local icon = config.icons[hint.kind]
 					local pad = i ~= 1 and " " or ""
 					hintsMerged = hintsMerged .. pad .. icon .. hint.label
 				end


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

Some LSPs like Rust Analyzer make heavy use of `nil` values for InlayHintKind (i.e. when `closingBraceHints` is set to true), which results in an unknown symbol. This PR allows customizing the symbol for when InlayHintKind is unknown, which should make these occurrences look less like an error.