### PR TITLE
feat: allow enable/disable option for icons

### DIFF
--- a/doc/lsp-endhints.txt
+++ b/doc/lsp-endhints.txt
@@ -49,7 +49,7 @@ INSTALLATION                    *lsp-endhints-nvim-lsp-endhints--installation*
         event = "LspAttach",
         opts = {}, -- required, even if empty
     },
-    
+
     -- packer
     use {
         "chrisgrieser/nvim-lsp-endhints",
@@ -65,6 +65,7 @@ The `.setup()` call is required.
     -- default settings
     require("lsp-endhints").setup {
         icons = {
+            enabled = true,
             type = "󰜁 ",
             parameter = "󰏪 ",
             offspec = " ", -- hint kind not defined in official LSP spec
@@ -98,10 +99,10 @@ and `toggle` functions:
 >lua
     -- inlay hints will show at the end of the line (default)
     require("lsp-endhints").enable()
-    
+
     -- inlay hints will show as if the plugin was not installed
     require("lsp-endhints").disable()
-    
+
     -- toggle between the two
     require("lsp-endhints").toggle()
 <
@@ -147,7 +148,7 @@ HOW TO ENABLE INLAY HINTS FOR A LANGUAGE? ~
             },
         },
     }
-    
+
     -- tsserver
     local inlayHints = {
         includeInlayParameterNameHints = "all",
@@ -169,7 +170,7 @@ HOW TO ENABLE INLAY HINTS FOR A LANGUAGE? ~
             },
         },
     }
-    
+
     -- gopls
     require("lspconfig").gopls.setup {
         settings = {
@@ -184,7 +185,7 @@ HOW TO ENABLE INLAY HINTS FOR A LANGUAGE? ~
             },
         },
     }
-    
+
     -- clangd
     require("lspconfig").clangd.setup {
         settings = {

--- a/lua/lsp-endhints/config.lua
+++ b/lua/lsp-endhints/config.lua
@@ -4,6 +4,7 @@ local M = {}
 ---@class LspEndhints.config
 local defaultConfig = {
 	icons = {
+		enabled = true,
 		type = "󰜁 ",
 		parameter = "󰏪 ",
 		offspec = " ", -- hint kind not defined in official LSP spec

--- a/lua/lsp-endhints/override-handler.lua
+++ b/lua/lsp-endhints/override-handler.lua
@@ -79,7 +79,7 @@ local function changedRefreshHandler(err, result, ctx, _)
 			if lastKind == hint.kind then
 				hintsMerged = hintsMerged .. ", " .. hint.label
 			else
-				local icon = config.icons[hint.kind]
+				local icon = config.icons.enabled and config.icons[hint.kind] or ""
 				local pad = i ~= 1 and " " or ""
 				hintsMerged = hintsMerged .. pad .. icon .. hint.label
 			end


### PR DESCRIPTION
## Checklist
- [X] Used only camelCase variable names.
- [X] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

This feature allows someone to enable or disable the use of icons in their configuration without having to manually set the value of each hint to "". This is helpful when someone is using an un-patched font, or one that doesn't contain icons. 